### PR TITLE
Fix path in sym-lib-table

### DIFF
--- a/sym-lib-table
+++ b/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name nfc_hat)(type Legacy)(uri C:/Users/dangf/workspace/sbc-fish/NFC-Hat/nfc_hat.lib)(options "")(descr ""))
+  (lib (name nfc_hat)(type Legacy)(uri ${KIPRJMOD}/nfc_hat.lib)(options "")(descr ""))
 )


### PR DESCRIPTION
Use variable instead of hard-coded path for local library

Signed-off-by: Zamir SUN <sztsian@gmail.com>